### PR TITLE
docs: bun -> bunx && remove -y

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add to `.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "bunx -y gh-setup-hooks",
+            "command": "bun x gh-setup-hooks",
             "timeout": 120
           }
         ]


### PR DESCRIPTION
- bun doesn't accept `-y` option
- some environment only has `bun` command, so `bun x` is safer than using `bunx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example command syntax in hook configuration documentation to maintain consistency and clarity for users configuring their development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->