### PR TITLE
feat: auto-detect GH_REPO from git remote URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ Claude Code on the Web network should be **Full** or **Custom**. If using **Cust
 2. SessionStart hook runs `npx gh-setup-hooks`
 3. Installs gh only in remote environment (`CLAUDE_CODE_REMOTE=true`)
 4. Installs to `~/.local/bin` and persists PATH
-5. Does nothing in local environment
+5. Auto-detects `GH_REPO` from git remote for `gh` CLI compatibility
+6. Does nothing in local environment
 
 ## Configuration
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `GH_SETUP_VERSION` | gh version to install | `2.83.2` |
+| `GH_SETUP_VERSION` | gh version to install | `2.88.1` |
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "type": "git",
     "url": "https://github.com/oikon48/gh-setup-hooks"
   },
+  "scripts": {
+    "test": "node --test 'test/**/*.test.js'"
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-setup-hooks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "One-line setup for GitHub CLI auto-installation on Claude Code on the Web",
   "type": "module",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -16,32 +16,47 @@ function log(msg) {
   console.error(`${LOG_PREFIX} ${msg}`);
 }
 
+// Validate owner/repo contains only safe characters
+const VALID_GH_REPO = /^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
+
 function parseGhRepo(remoteUrl) {
   if (!remoteUrl) return null;
   const cleaned = remoteUrl.trim().replace(/\.git$/, '');
 
+  let repo = null;
+
   // Proxy URL: http://local_proxy@127.0.0.1:PORT/git/owner/repo
   const proxyMatch = cleaned.match(/\/git\/([^/]+\/[^/]+)$/);
-  if (proxyMatch) return proxyMatch[1];
+  if (proxyMatch) repo = proxyMatch[1];
 
   // SSH URL scheme: ssh://git@github.com/owner/repo
-  const sshUrlMatch = cleaned.match(/ssh:\/\/[^@]+@github\.com\/([^/]+\/[^/]+)$/);
-  if (sshUrlMatch) return sshUrlMatch[1];
+  if (!repo) {
+    const sshUrlMatch = cleaned.match(/ssh:\/\/[^@]+@github\.com\/([^/]+\/[^/]+)$/);
+    if (sshUrlMatch) repo = sshUrlMatch[1];
+  }
 
   // HTTPS: https://github.com/owner/repo
-  const httpsMatch = cleaned.match(/github\.com\/([^/]+\/[^/]+)$/);
-  if (httpsMatch) return httpsMatch[1];
+  if (!repo) {
+    const httpsMatch = cleaned.match(/\/\/github\.com\/([^/]+\/[^/]+)$/);
+    if (httpsMatch) repo = httpsMatch[1];
+  }
 
   // SSH SCP: git@github.com:owner/repo
-  const sshMatch = cleaned.match(/github\.com:([^/]+\/[^/]+)$/);
-  if (sshMatch) return sshMatch[1];
+  if (!repo) {
+    const sshMatch = cleaned.match(/@github\.com:([^/]+\/[^/]+)$/);
+    if (sshMatch) repo = sshMatch[1];
+  }
 
+  if (repo && VALID_GH_REPO.test(repo)) return repo;
   return null;
 }
 
 function setupGhRepo() {
   const envFile = process.env.CLAUDE_ENV_FILE;
   if (!envFile) return;
+
+  // Skip if GH_REPO already set
+  if (process.env.GH_REPO) return;
 
   try {
     const remoteUrl = execSync('git remote get-url origin', {

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,49 @@ function log(msg) {
   console.error(`${LOG_PREFIX} ${msg}`);
 }
 
+function parseGhRepo(remoteUrl) {
+  if (!remoteUrl) return null;
+  const cleaned = remoteUrl.trim().replace(/\.git$/, '');
+
+  // Proxy URL: http://local_proxy@127.0.0.1:PORT/git/owner/repo
+  const proxyMatch = cleaned.match(/\/git\/([^/]+\/[^/]+)$/);
+  if (proxyMatch) return proxyMatch[1];
+
+  // SSH URL scheme: ssh://git@github.com/owner/repo
+  const sshUrlMatch = cleaned.match(/ssh:\/\/[^@]+@github\.com\/([^/]+\/[^/]+)$/);
+  if (sshUrlMatch) return sshUrlMatch[1];
+
+  // HTTPS: https://github.com/owner/repo
+  const httpsMatch = cleaned.match(/github\.com\/([^/]+\/[^/]+)$/);
+  if (httpsMatch) return httpsMatch[1];
+
+  // SSH SCP: git@github.com:owner/repo
+  const sshMatch = cleaned.match(/github\.com:([^/]+\/[^/]+)$/);
+  if (sshMatch) return sshMatch[1];
+
+  return null;
+}
+
+function setupGhRepo() {
+  const envFile = process.env.CLAUDE_ENV_FILE;
+  if (!envFile) return;
+
+  try {
+    const remoteUrl = execSync('git remote get-url origin', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    const repo = parseGhRepo(remoteUrl);
+    if (repo) {
+      fs.appendFileSync(envFile, `export GH_REPO="${repo}"\n`);
+      log(`GH_REPO set to ${repo}`);
+    }
+  } catch (e) {
+    // Not in a git repository or no origin remote — silently skip
+  }
+}
+
 function updatePath() {
   const envFile = process.env.CLAUDE_ENV_FILE;
   if (envFile) {
@@ -37,6 +80,7 @@ function run() {
   try {
     const version = execSync('gh --version', { encoding: 'utf8' }).split('\n')[0];
     log(`gh CLI already available: ${version}`);
+    setupGhRepo();
     process.exit(0);
   } catch (e) {
     // gh not found, continue with installation
@@ -46,6 +90,7 @@ function run() {
   if (fs.existsSync(GH_PATH)) {
     log(`gh found in ${LOCAL_BIN}`);
     updatePath();
+    setupGhRepo();
     process.exit(0);
   }
 
@@ -103,6 +148,7 @@ function run() {
     fs.chmodSync(GH_PATH, 0o755);
 
     updatePath();
+    setupGhRepo();
 
     const version = execSync(`${GH_PATH} --version`, { encoding: 'utf8' }).split('\n')[0];
     log(`gh CLI installed successfully: ${version}`);
@@ -115,4 +161,4 @@ function run() {
   process.exit(0);
 }
 
-export { run as main };
+export { run as main, parseGhRepo, ARCH_MAP };

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import os from 'os';
 const LOG_PREFIX = '[gh-setup-hooks]';
 const LOCAL_BIN = `${process.env.HOME}/.local/bin`;
 const GH_PATH = `${LOCAL_BIN}/gh`;
-const DEFAULT_GH_VERSION = '2.83.2';
+const DEFAULT_GH_VERSION = '2.88.1';
 
 const ARCH_MAP = {
   x64: 'amd64',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,105 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseGhRepo, ARCH_MAP } from '../src/index.js';
+
+describe('ARCH_MAP', () => {
+  it('maps x64 to amd64', () => {
+    assert.equal(ARCH_MAP.x64, 'amd64');
+  });
+
+  it('maps arm64 to arm64', () => {
+    assert.equal(ARCH_MAP.arm64, 'arm64');
+  });
+});
+
+describe('parseGhRepo', () => {
+  describe('Proxy URLs', () => {
+    it('extracts owner/repo from proxy URL', () => {
+      assert.equal(
+        parseGhRepo('http://local_proxy@127.0.0.1:48052/git/owner/repo'),
+        'owner/repo'
+      );
+    });
+
+    it('extracts owner/repo from proxy URL with .git suffix', () => {
+      assert.equal(
+        parseGhRepo('http://local_proxy@127.0.0.1:48052/git/owner/repo.git'),
+        'owner/repo'
+      );
+    });
+  });
+
+  describe('HTTPS URLs', () => {
+    it('extracts owner/repo from HTTPS URL', () => {
+      assert.equal(
+        parseGhRepo('https://github.com/owner/repo'),
+        'owner/repo'
+      );
+    });
+
+    it('extracts owner/repo from HTTPS URL with .git suffix', () => {
+      assert.equal(
+        parseGhRepo('https://github.com/owner/repo.git'),
+        'owner/repo'
+      );
+    });
+  });
+
+  describe('SSH URLs', () => {
+    it('extracts owner/repo from SSH SCP URL', () => {
+      assert.equal(
+        parseGhRepo('git@github.com:owner/repo'),
+        'owner/repo'
+      );
+    });
+
+    it('extracts owner/repo from SSH SCP URL with .git suffix', () => {
+      assert.equal(
+        parseGhRepo('git@github.com:owner/repo.git'),
+        'owner/repo'
+      );
+    });
+
+    it('extracts owner/repo from ssh:// URL', () => {
+      assert.equal(
+        parseGhRepo('ssh://git@github.com/owner/repo'),
+        'owner/repo'
+      );
+    });
+
+    it('extracts owner/repo from ssh:// URL with .git suffix', () => {
+      assert.equal(
+        parseGhRepo('ssh://git@github.com/owner/repo.git'),
+        'owner/repo'
+      );
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('returns null for null input', () => {
+      assert.equal(parseGhRepo(null), null);
+    });
+
+    it('returns null for undefined input', () => {
+      assert.equal(parseGhRepo(undefined), null);
+    });
+
+    it('returns null for empty string', () => {
+      assert.equal(parseGhRepo(''), null);
+    });
+
+    it('returns null for non-GitHub URL', () => {
+      assert.equal(
+        parseGhRepo('https://gitlab.com/owner/repo'),
+        null
+      );
+    });
+
+    it('handles trailing whitespace', () => {
+      assert.equal(
+        parseGhRepo('https://github.com/owner/repo  \n'),
+        'owner/repo'
+      );
+    });
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -95,6 +95,20 @@ describe('parseGhRepo', () => {
       );
     });
 
+    it('returns null for similar host like notgithub.com', () => {
+      assert.equal(
+        parseGhRepo('https://notgithub.com/owner/repo'),
+        null
+      );
+    });
+
+    it('returns null for URL with shell metacharacters', () => {
+      assert.equal(
+        parseGhRepo('http://127.0.0.1:8080/git/owner$(id)/repo'),
+        null
+      );
+    });
+
     it('handles trailing whitespace', () => {
       assert.equal(
         parseGhRepo('https://github.com/owner/repo  \n'),


### PR DESCRIPTION
## Summary

- **GH_REPO auto-detection**: `parseGhRepo()` extracts `owner/repo` from proxy, HTTPS, and SSH (SCP + `ssh://` scheme) git remote URLs and persists `GH_REPO` to `CLAUDE_ENV_FILE`
- **gh CLI version bump**: Default version updated from 2.83.2 to 2.88.1

## Related

- Closes #3

## Test plan

- [x] All 15 unit tests pass (`npm test`)
- [ ] Manual test in Claude Code on the Web: confirm `GH_REPO` is set correctly from proxy remote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and configuration of the GitHub repository from the local git origin for improved CLI integration.

* **Chores**
  * Updated GitHub CLI default to v2.88.1.
  * Bumped package patch version to 2.0.1.
  * Added a top-level test script to run the project's tests.

* **Tests**
  * Added a comprehensive test suite covering repository parsing and architecture mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->